### PR TITLE
Fix Game Breaking Bugs

### DIFF
--- a/Assets/LAGS/Prefabs/Props/Table Double.prefab
+++ b/Assets/LAGS/Prefabs/Props/Table Double.prefab
@@ -247,8 +247,6 @@ MonoBehaviour:
   - {fileID: 9048134547464068056}
   _orderReadyMarker: {fileID: 6532625137154899875}
   _startingPoints: 100
-  _ratingTime: 2
-  _pointsToReduce: 10
   _threeStarsRating: {x: 80, y: 100}
   _twoStarsRating: {x: 31, y: 79}
   _oneStarsRating: {x: 1, y: 30}
@@ -392,7 +390,7 @@ MonoBehaviour:
   - {x: 0.793218, y: -0.44223833, z: 0}
   m_ShapePathHash: 0
   m_Mesh: {fileID: 0}
-  m_InstanceId: 57754
+  m_InstanceId: 51524
   m_LocalBounds:
     m_Center: {x: -0.00088334084, y: 0.05270052, z: 0}
     m_Extent: {x: 0.79410136, y: 0.49493885, z: 0}
@@ -777,6 +775,7 @@ Transform:
   - {fileID: 1048887459999673966}
   - {fileID: 2926052567562769248}
   - {fileID: 6018815167785094391}
+  - {fileID: 5493831173861974625}
   m_Father: {fileID: 7227280561271843141}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6261817964111500517
@@ -991,6 +990,90 @@ SpriteRenderer:
   m_FlipY: 0
   m_DrawMode: 0
   m_Size: {x: 0.2, y: 0.2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &7891460477107482759
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5493831173861974625}
+  - component: {fileID: 1945570665993471833}
+  m_Layer: 6
+  m_Name: BG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5493831173861974625
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7891460477107482759}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 15.4, y: 4.02, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7811841755612497584}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1945570665993471833
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7891460477107482759}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1000
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.01, y: 0.65}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1

--- a/Assets/LAGS/Prefabs/Props/Table_Circular.prefab
+++ b/Assets/LAGS/Prefabs/Props/Table_Circular.prefab
@@ -277,8 +277,6 @@ MonoBehaviour:
   - {fileID: 8227853767652863136}
   _orderReadyMarker: {fileID: 5785366231317078420}
   _startingPoints: 100
-  _ratingTime: 2
-  _pointsToReduce: 10
   _threeStarsRating: {x: 80, y: 100}
   _twoStarsRating: {x: 31, y: 79}
   _oneStarsRating: {x: 1, y: 30}
@@ -428,7 +426,7 @@ MonoBehaviour:
   - {x: -0.3047818, y: 0.27390546, z: 0}
   m_ShapePathHash: -1282080687
   m_Mesh: {fileID: 0}
-  m_InstanceId: 57946
+  m_InstanceId: 51724
   m_LocalBounds:
     m_Center: {x: 0.0055412054, y: 0.12805477, z: 0}
     m_Extent: {x: 0.39453268, y: 0.28184903, z: 0}
@@ -696,6 +694,90 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &3244039809127822072
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1035880126542613061}
+  - component: {fileID: 1755473435994918347}
+  m_Layer: 6
+  m_Name: BG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1035880126542613061
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3244039809127822072}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 15.399999, y: 4.02, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7434584616855966513}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1755473435994918347
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3244039809127822072}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1000
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.01, y: 0.65}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &5296484239639604778
 GameObject:
   m_ObjectHideFlags: 0
@@ -729,6 +811,7 @@ Transform:
   - {fileID: 4727461243599507816}
   - {fileID: 1601378846264635330}
   - {fileID: 2825161202397698419}
+  - {fileID: 1035880126542613061}
   m_Father: {fileID: 916516613005000892}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5785366231317078420

--- a/Assets/LAGS/Prefabs/Props/Table_Double A.prefab
+++ b/Assets/LAGS/Prefabs/Props/Table_Double A.prefab
@@ -33,6 +33,7 @@ Transform:
   - {fileID: 4305319985540830626}
   - {fileID: 6859891401783585243}
   - {fileID: 7420166655788336839}
+  - {fileID: 8304782841297844746}
   m_Father: {fileID: 1033695937533112422}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &212007496182803682
@@ -183,8 +184,6 @@ MonoBehaviour:
   - {fileID: 61992902004616921}
   _orderReadyMarker: {fileID: 2916977956212441319}
   _startingPoints: 100
-  _ratingTime: 2
-  _pointsToReduce: 10
   _threeStarsRating: {x: 80, y: 100}
   _twoStarsRating: {x: 31, y: 79}
   _oneStarsRating: {x: 1, y: 30}
@@ -327,7 +326,7 @@ MonoBehaviour:
   - {x: -0.38899148, y: 0.106355816, z: 0}
   m_ShapePathHash: 1490502855
   m_Mesh: {fileID: 0}
-  m_InstanceId: 58202
+  m_InstanceId: 51992
   m_LocalBounds:
     m_Center: {x: 0.2427913, y: -0.0025661588, z: 0}
     m_Extent: {x: 0.63178277, y: 0.41246992, z: 0}
@@ -1094,6 +1093,90 @@ NavMeshObstacle:
   m_CarveOnlyStationary: 1
   m_Center: {x: 0, y: 0, z: 0}
   m_TimeToStationary: 0.5
+--- !u!1 &7395661404097720384
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8304782841297844746}
+  - component: {fileID: 3158870065748703004}
+  m_Layer: 6
+  m_Name: BG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8304782841297844746
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7395661404097720384}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 15.399999, y: 4.02, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4260985546695213963}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &3158870065748703004
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7395661404097720384}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1000
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.01, y: 0.65}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &8296402741498994896
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/LAGS/Prefabs/Props/Table_Double B.prefab
+++ b/Assets/LAGS/Prefabs/Props/Table_Double B.prefab
@@ -1,5 +1,89 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &90937284387858292
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4549245650622813990}
+  - component: {fileID: 6958094640007264276}
+  m_Layer: 6
+  m_Name: BG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4549245650622813990
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 90937284387858292}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 15.399999, y: 4.02, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1288167302340446865}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &6958094640007264276
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 90937284387858292}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1000
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.01, y: 0.65}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &712436555120204543
 GameObject:
   m_ObjectHideFlags: 0
@@ -148,8 +232,6 @@ MonoBehaviour:
   - {fileID: 969750482406516367}
   _orderReadyMarker: {fileID: 7937610122768447037}
   _startingPoints: 100
-  _ratingTime: 2
-  _pointsToReduce: 10
   _threeStarsRating: {x: 80, y: 100}
   _twoStarsRating: {x: 31, y: 79}
   _oneStarsRating: {x: 1, y: 30}
@@ -292,7 +374,7 @@ MonoBehaviour:
   - {x: -0.38899148, y: 0.106355816, z: 0}
   m_ShapePathHash: 1490502855
   m_Mesh: {fileID: 0}
-  m_InstanceId: 58404
+  m_InstanceId: 52206
   m_LocalBounds:
     m_Center: {x: 0.2427913, y: -0.0025661588, z: 0}
     m_Extent: {x: 0.63178277, y: 0.41246992, z: 0}
@@ -960,6 +1042,7 @@ Transform:
   - {fileID: 2515429138994586931}
   - {fileID: 7793612970287657683}
   - {fileID: 6211680289191132300}
+  - {fileID: 4549245650622813990}
   m_Father: {fileID: 3595528318384952541}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7937610122768447037

--- a/Assets/LAGS/Prefabs/Props/Table_Simple.prefab
+++ b/Assets/LAGS/Prefabs/Props/Table_Simple.prefab
@@ -168,6 +168,90 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &2306963290931039468
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7108752183821882525}
+  - component: {fileID: 4005797402776318321}
+  m_Layer: 6
+  m_Name: BG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7108752183821882525
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2306963290931039468}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 15.399999, y: 4.02, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9002485969735350143}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &4005797402776318321
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2306963290931039468}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1000
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.01, y: 0.65}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &2339540378989602757
 GameObject:
   m_ObjectHideFlags: 0
@@ -249,6 +333,7 @@ Transform:
   - {fileID: 8929088352837900217}
   - {fileID: 7718455934139682365}
   - {fileID: 9024781102414205250}
+  - {fileID: 7108752183821882525}
   m_Father: {fileID: 5759990758504292311}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2536759448298978898
@@ -516,8 +601,6 @@ MonoBehaviour:
   - {fileID: 3355514752215942198}
   _orderReadyMarker: {fileID: 4503989600207425297}
   _startingPoints: 100
-  _ratingTime: 2
-  _pointsToReduce: 10
   _threeStarsRating: {x: 80, y: 100}
   _twoStarsRating: {x: 31, y: 79}
   _oneStarsRating: {x: 1, y: 30}
@@ -659,7 +742,7 @@ MonoBehaviour:
   - {x: -0.38899148, y: 0.106355816, z: 0}
   m_ShapePathHash: -2140966595
   m_Mesh: {fileID: 0}
-  m_InstanceId: 58624
+  m_InstanceId: 52438
   m_LocalBounds:
     m_Center: {x: 0.0055412054, y: 0.12805477, z: 0}
     m_Extent: {x: 0.39453268, y: 0.28184903, z: 0}

--- a/Assets/LAGS/Scripts/Client/Client.cs
+++ b/Assets/LAGS/Scripts/Client/Client.cs
@@ -376,6 +376,7 @@ namespace LAGS.Clients
         
         public void Escape()
         {
+            _fov.enabled = false;
             _chair.Leave();
             _isSitting = false;
             _animator.SetBool("IsSitting", false);

--- a/Assets/LAGS/Scripts/Player/PlayerAnimations.cs
+++ b/Assets/LAGS/Scripts/Player/PlayerAnimations.cs
@@ -19,10 +19,22 @@ namespace LAGS
         [SerializeField] private string _twoPlateParameterName = "TwoPlates";
         [SerializeField] private string _cleanParameterName = "IsCleaning";
 
-        // Update is called once per frame
-        void Update()
+        private bool _isDayOver;
+
+        private void OnEnable()
         {
-            if (PubManager.Instance.IsDayOver) { return; }
+            PubManager.Instance.DayFinished.RemoveListener(DayOver);
+            PubManager.Instance.DayFinished.AddListener(DayOver);
+        }
+
+        private void OnDisable()
+        {
+            PubManager.Instance.DayFinished.RemoveListener(DayOver);
+        }
+
+        private void Update()
+        {
+            if (_isDayOver) { return; }
             
             UpdateAnimator();
         }
@@ -49,6 +61,11 @@ namespace LAGS
 
             _animator.SetFloat(_moveXParameterName, moveX);
             _animator.SetFloat(_moveYParameterName, moveY);
+        }
+
+        private void DayOver()
+        {
+            _isDayOver = true;
         }
 
         public void SetOnePlate(bool value)

--- a/Assets/LAGS/Scripts/UI/Receipt.cs
+++ b/Assets/LAGS/Scripts/UI/Receipt.cs
@@ -1,3 +1,4 @@
+using System;
 using DG.Tweening;
 using LAGS.Managers.Pub;
 using SombraStudios.Shared.Scenes;
@@ -33,9 +34,15 @@ namespace LAGS
 
         private void Start()
         {
-            PubManager.Instance.DayFinished.AddListener(OnDayOver);
-            _nextButton.onClick.AddListener(ChangeScene);
             _rectTransform = GetComponent<RectTransform>();
+        }
+
+        private void OnEnable()
+        {
+            PubManager.Instance.DayFinished.RemoveListener(OnDayOver);
+            PubManager.Instance.DayFinished.AddListener(OnDayOver);
+            _nextButton.onClick.RemoveListener(ChangeScene);
+            _nextButton.onClick.AddListener(ChangeScene);
         }
 
         private void OnDisable()

--- a/Assets/LAGS/Scripts/UI/Receipt.cs
+++ b/Assets/LAGS/Scripts/UI/Receipt.cs
@@ -38,7 +38,7 @@ namespace LAGS
             _rectTransform = GetComponent<RectTransform>();
         }
 
-        private void OnDestroy()
+        private void OnDisable()
         {
             PubManager.Instance.DayFinished.RemoveListener(OnDayOver);
             _nextButton.onClick.RemoveListener(ChangeScene);
@@ -69,7 +69,7 @@ namespace LAGS
             }
             else
             {
-                SceneController.Instance.Restart();
+                SceneController.Instance.ReloadScene();
             }
         }
     }


### PR DESCRIPTION
- Fixed that the Receipt Script creates a new PubManager Instance onDestroy and lost the information for the next level
- Fixed that the Receipt Script, when you lose, made you start from the beginning instead repeat the level
- Fixed that the Player Animations stop playing if the time was over but there were some clients
- Disable the FOV visuals when the clients leave the table
- Added a BG sprite to the rating UI in the tables